### PR TITLE
added remaining screens and navigation

### DIFF
--- a/plentyofpets/lib/components/admin_homepage_buttons.dart
+++ b/plentyofpets/lib/components/admin_homepage_buttons.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 import '../screens/add_pet_screen.dart';
-
+import '../screens/admin_pet_list_screen.dart';
+import '../screens/add_news_screen.dart';
 
 class AddPetCardButton extends StatelessWidget {
   final String buttonText;
 
-  const AddPetCardButton({required this.buttonText, Key? key}) : super(key: key);
+  const AddPetCardButton({required this.buttonText, Key? key})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -24,8 +26,8 @@ class AddPetCardButton extends StatelessWidget {
           children: <Widget>[
             TextButton(
                 onPressed: () {
-                  Navigator.of(context).push(
-                      MaterialPageRoute(builder: (context) => AddPetScreen()));
+                  Navigator.of(context).push(MaterialPageRoute(
+                      builder: (context) => const AddPetScreen()));
                 },
                 child: Text(buttonText)),
           ],
@@ -38,7 +40,8 @@ class AddPetCardButton extends StatelessWidget {
 class EditPetListCardButton extends StatelessWidget {
   final String buttonText;
 
-  const EditPetListCardButton({required this.buttonText, Key? key}) : super(key: key);
+  const EditPetListCardButton({required this.buttonText, Key? key})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -57,8 +60,8 @@ class EditPetListCardButton extends StatelessWidget {
           children: <Widget>[
             TextButton(
                 onPressed: () {
-                  Navigator.of(context).push(
-                      MaterialPageRoute(builder: (context) => AddPetScreen()));
+                  Navigator.of(context).push(MaterialPageRoute(
+                      builder: (context) => const AdminPetList()));
                 },
                 child: Text(buttonText)),
           ],
@@ -71,7 +74,8 @@ class EditPetListCardButton extends StatelessWidget {
 class AddNewsCardButton extends StatelessWidget {
   final String buttonText;
 
-  const AddNewsCardButton({required this.buttonText, Key? key}) : super(key: key);
+  const AddNewsCardButton({required this.buttonText, Key? key})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -91,7 +95,7 @@ class AddNewsCardButton extends StatelessWidget {
             TextButton(
                 onPressed: () {
                   Navigator.of(context).push(
-                      MaterialPageRoute(builder: (context) => AddPetScreen()));
+                      MaterialPageRoute(builder: (context) => const AddNewsScreen()));
                 },
                 child: Text(buttonText)),
           ],
@@ -104,7 +108,8 @@ class AddNewsCardButton extends StatelessWidget {
 class AccountInfoCardButton extends StatelessWidget {
   final String buttonText;
 
-  const AccountInfoCardButton({required this.buttonText, Key? key}) : super(key: key);
+  const AccountInfoCardButton({required this.buttonText, Key? key})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/plentyofpets/lib/screens/add_news_screen.dart
+++ b/plentyofpets/lib/screens/add_news_screen.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 
-class AddPetScreen extends StatelessWidget {
-  const AddPetScreen({Key? key}) : super(key: key);
+class AddNewsScreen extends StatelessWidget {
+  const AddNewsScreen({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Add a Pet'),
+        title: const Text('Add a News piece'),
       ),
       body: Center(
         child: ElevatedButton(

--- a/plentyofpets/lib/screens/admin_pet_list_screen.dart
+++ b/plentyofpets/lib/screens/admin_pet_list_screen.dart
@@ -1,13 +1,14 @@
 import 'package:flutter/material.dart';
 
-class AddPetScreen extends StatelessWidget {
-  const AddPetScreen({Key? key}) : super(key: key);
+// Displays the entire catalog of animals an organization has
+class AdminPetList extends StatelessWidget {
+  const AdminPetList({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Add a Pet'),
+        title: const Text('Admin Pet List'),
       ),
       body: Center(
         child: ElevatedButton(

--- a/plentyofpets/lib/screens/home_screen.dart
+++ b/plentyofpets/lib/screens/home_screen.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:plentyofpets/components/nav_drawer.dart';
 import '../components/user_profile.dart';
 import '../components/pets_list.dart';
+import '../screens/saved_pet_list_screen.dart';
+import '../screens/news_feed.dart'; // stretch
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({Key? key}) : super(key: key);
@@ -16,17 +18,19 @@ class HomeScreen extends StatelessWidget {
         appBar: AppBar(),
         drawer: const Drawer(child: NavDrawer()),
         bottomNavigationBar: menu(),
-        body: TabBarView(
+        body: const TabBarView(
           children: <Widget>[
             Center(
               // Display a list of pets from the database
               child: PetList(),
             ),
             Center(
-              child: Text("News Feed page"),
+              // Stretch goal
+              child: NewsFeed(),
             ),
+            // Users saved pets list
             Center(
-              child: Text("Saved animals page"),
+              child: SavedPetList(),
             ),
             Center(
               // Display the user profile page
@@ -41,12 +45,12 @@ class HomeScreen extends StatelessWidget {
 
 Widget menu() {
   return Container(
-    color: Color(0xFF3F5AA6),
-    child: TabBar(
+    color: const Color(0xFF3F5AA6),
+    child: const TabBar(
       labelColor: Colors.white,
       unselectedLabelColor: Colors.white70,
       indicatorSize: TabBarIndicatorSize.tab,
-      indicatorPadding: EdgeInsets.all(5.0),
+      indicatorPadding: const EdgeInsets.all(5.0),
       indicatorColor: Colors.blueGrey,
       tabs: [
         Tab(

--- a/plentyofpets/lib/screens/news_feed.dart
+++ b/plentyofpets/lib/screens/news_feed.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+// Displays News Feed (stretch goal)
+class NewsFeed extends StatelessWidget {
+  const NewsFeed({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('News Feed!'),
+      ),
+      body: Center(
+        child: Placeholder(),
+      ),
+    );
+  }
+}

--- a/plentyofpets/lib/screens/saved_pet_list_screen.dart
+++ b/plentyofpets/lib/screens/saved_pet_list_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class SavedPetList extends StatelessWidget {
+  const SavedPetList({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Saved Pets List'),
+      ),
+      body: const Center(
+        child: Text('Go back!'),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Added the remaining screens for some completeness when interacting with homepage buttons/tabs. 

These include:
- Admin profile page
- Org's animal list
- User's saved animals list
- News feed screen (stretch goal, so we can even remove it as well)