### PR TITLE
Add pet pictures and admin id to firestore

### DIFF
--- a/plentyofpets/android/build.gradle
+++ b/plentyofpets/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         mavenCentral()

--- a/plentyofpets/lib/components/add_edit_pet_form.dart
+++ b/plentyofpets/lib/components/add_edit_pet_form.dart
@@ -181,14 +181,14 @@ class _AddPetFormState extends State<AddPetForm> {
                         };
 
                         //gets admin info from firebase
-                        // Map adminInfo = await currentPet.getAdmin(adminUser);
-                        // print(adminInfo);
+                        Map adminInfo = await currentPet.getAdmin(adminUser);
 
                         //adds pet form info to pet details sub collection
                         currentPet.addPetDetails( 
                           id, 
                           petFormData['Description'],
                           petFormData['Pet Name'],
+                          adminInfo,
                           picStorage,
                         );
                         

--- a/plentyofpets/lib/components/add_edit_pet_form.dart
+++ b/plentyofpets/lib/components/add_edit_pet_form.dart
@@ -1,9 +1,14 @@
 import 'package:flutter/material.dart';
+import 'dart:io';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:form_builder_image_picker/form_builder_image_picker.dart';
 import 'package:form_builder_validators/form_builder_validators.dart';
+import 'package:image_picker/image_picker.dart';
+//import 'package:xfile/xfile.dart';
+import 'package:firebase_storage/firebase_storage.dart' as firebase_storage;
 import 'package:plentyofpets/services/pet_database.dart';
 import 'package:plentyofpets/screens/admin_homepage.dart';
+import 'package:plentyofpets/services/pet_pics.dart';
 
 class AddPetForm extends StatefulWidget {
   const AddPetForm({Key? key}) : super(key: key);
@@ -16,6 +21,7 @@ class _AddPetFormState extends State<AddPetForm> {
   final List<String> availableOptions=['Not Available','Available','Pending','Adopted'];
   String? petType;
   Map<String,dynamic> petFormData = {};
+
   
   @override
   Widget build(BuildContext context) {
@@ -164,10 +170,19 @@ class _AddPetFormState extends State<AddPetForm> {
                         petFormData['Breed'],
                         petFormData['Pet Name'],
                         );
+                        
+                        List<String> picStorage = [];
+                        if (petFormData['photos'] == null){
+                          picStorage[0] = 'gs:/plenty-of-pets-339013.appspot.com/Default photo/IMAGE-COMING-SOON.jpg';
+                        } else{
+                          picStorage = PetPics(petFormData['photos']).addPetPics(id);
+                        };
+
                         DatabaseService().addPetDetails( 
                           id, 
                           petFormData['Description'],
                           petFormData['Pet Name'],
+                          picStorage,
                         );
                         Navigator.of(context).push(
                         MaterialPageRoute(builder: (context) => const AdminHomepage()));

--- a/plentyofpets/lib/services/pet_database.dart
+++ b/plentyofpets/lib/services/pet_database.dart
@@ -22,12 +22,13 @@ class DatabaseService {
     }
     
     //adds pet detail to pet with pet id from add pet form
-    Future addPetDetails(var petId,var description, var name) async 
+    Future addPetDetails(var petId,var description, var name, var photos) async 
     {
       return await petsCollection.doc(petId).collection('pet_details').add
       ({
         'description': description,
         'name':name,
+        'photos':photos
       });
     }
 }

--- a/plentyofpets/lib/services/pet_database.dart
+++ b/plentyofpets/lib/services/pet_database.dart
@@ -1,14 +1,32 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 
 class DatabaseService {
   final String id='';
+  User? currentUser;
   
   //collection reference
   final CollectionReference petsCollection = FirebaseFirestore.instance.collection('pets');
+  final CollectionReference usersCollection = FirebaseFirestore.instance.collection('users');
+
+  //returns the current user ID to be added to pet admin field
+  String? getUser(){
+    currentUser = FirebaseAuth.instance.currentUser;
+    return currentUser!.uid;
+  }
+
+  //returns admin info to be added to pet details field. 
+  // Future getAdmin(admin)async{
+  //   Map adminInfo={'adminId':admin};
+  //   DocumentSnapshot adminSnapshot= await usersCollection.doc('$admin').get();
+  //   adminInfo['url']=adminSnapshot['url'];
+  //   adminInfo['organization']= adminSnapshot['organization'];
+  //   return adminInfo;
+  // }
 
   //adds new pet and captures pet id from add pet form
   Future addPet(var type,var availability,var disposition,var breed,
-    var name) async 
+    var name, admin) async 
     {
       return await petsCollection.add
       ({
@@ -17,18 +35,25 @@ class DatabaseService {
         'disposition':disposition,
         'breed':breed,
         'name': name,
-        'timestamp': FieldValue.serverTimestamp()
+        'timestamp': FieldValue.serverTimestamp(),
+        'admin': admin,
       }).then((value){return value.id;});
     }
     
     //adds pet detail to pet with pet id from add pet form
+    //makes additional call to add main photo to pets collection doc
     Future addPetDetails(var petId,var description, var name, var photos) async 
     {
       return await petsCollection.doc(petId).collection('pet_details').add
       ({
         'description': description,
         'name':name,
+        //'admin':adminInfo,
         'photos':photos
-      });
+      }).then((value)async{
+          return await petsCollection.doc(petId).set(
+            {'mainPhoto':photos[0]}, SetOptions(merge: true)
+          );
+        });
     }
 }

--- a/plentyofpets/lib/services/pet_database.dart
+++ b/plentyofpets/lib/services/pet_database.dart
@@ -16,13 +16,13 @@ class DatabaseService {
   }
 
   //returns admin info to be added to pet details field. 
-  // Future getAdmin(admin)async{
-  //   Map adminInfo={'adminId':admin};
-  //   DocumentSnapshot adminSnapshot= await usersCollection.doc('$admin').get();
-  //   adminInfo['url']=adminSnapshot['url'];
-  //   adminInfo['organization']= adminSnapshot['organization'];
-  //   return adminInfo;
-  // }
+  Future getAdmin(admin)async{
+    Map adminInfo={'adminId':admin};
+    DocumentSnapshot adminSnapshot= await usersCollection.doc('$admin').get();
+    adminInfo['url']=adminSnapshot['url'];
+    adminInfo['organization']= adminSnapshot['organization'];
+    return adminInfo;
+  }
 
   //adds new pet and captures pet id from add pet form
   Future addPet(var type,var availability,var disposition,var breed,
@@ -42,13 +42,13 @@ class DatabaseService {
     
     //adds pet detail to pet with pet id from add pet form
     //makes additional call to add main photo to pets collection doc
-    Future addPetDetails(var petId,var description, var name, var photos) async 
+    Future addPetDetails(var petId,var description, var name, var adminInfo,var photos) async 
     {
       return await petsCollection.doc(petId).collection('pet_details').add
       ({
         'description': description,
         'name':name,
-        //'admin':adminInfo,
+        'admin':adminInfo,
         'photos':photos
       }).then((value)async{
           return await petsCollection.doc(petId).set(

--- a/plentyofpets/lib/services/pet_pics.dart
+++ b/plentyofpets/lib/services/pet_pics.dart
@@ -1,0 +1,22 @@
+import 'package:firebase_storage/firebase_storage.dart' as firebase_storage;
+import 'dart:io';
+import 'package:image_picker/image_picker.dart';
+
+class PetPics{
+  List pictures;
+  List<String> picStorage = [];
+
+  PetPics(this.pictures);
+
+  List<String> addPetPics(id){ 
+    for(var i=0; i < pictures.length; i++){
+      var pic = pictures[i];
+      File petPic = File(pic.path);
+      firebase_storage.FirebaseStorage.instance
+        .ref('$id/petPic$i.jpg')
+        .putFile(petPic);
+      picStorage.add('$id/petPic$i.jpg');
+    };
+    return picStorage;
+  }
+}

--- a/plentyofpets/lib/services/pet_pics.dart
+++ b/plentyofpets/lib/services/pet_pics.dart
@@ -1,6 +1,6 @@
 import 'package:firebase_storage/firebase_storage.dart' as firebase_storage;
 import 'dart:io';
-import 'package:image_picker/image_picker.dart';
+//import 'package:image_picker/image_picker.dart';
 
 class PetPics{
   List pictures;

--- a/plentyofpets/lib/services/pet_pics.dart
+++ b/plentyofpets/lib/services/pet_pics.dart
@@ -1,6 +1,5 @@
 import 'package:firebase_storage/firebase_storage.dart' as firebase_storage;
 import 'dart:io';
-//import 'package:image_picker/image_picker.dart';
 
 class PetPics{
   List pictures;
@@ -8,15 +7,33 @@ class PetPics{
 
   PetPics(this.pictures);
 
-  List<String> addPetPics(id){ 
+  //add pet pictures submitted in the add pet form to firebase storage 
+  Future <List<String>> addPetPics(id)async {
     for(var i=0; i < pictures.length; i++){
       var pic = pictures[i];
+      var petRef = '$id/petPic$i.jpg';
       File petPic = File(pic.path);
-      firebase_storage.FirebaseStorage.instance
-        .ref('$id/petPic$i.jpg')
+      
+      await firebase_storage.FirebaseStorage.instance
+        .ref(petRef)
         .putFile(petPic);
-      picStorage.add('$id/petPic$i.jpg');
+      String petUrl = await downloadURL(petRef);
+      picStorage.add(petUrl);
     };
     return picStorage;
+  }
+
+  //retrieve the picture URL from firebase storage
+  Future downloadURL(petRef) async 
+    {
+     return await firebase_storage.FirebaseStorage.instance
+        .ref(petRef)
+        .getDownloadURL();
+  }
+
+  //list all pics for specific pet id provided
+  Future<void> listPics(id) async {
+    firebase_storage.ListResult result =
+        await firebase_storage.FirebaseStorage.instance.ref(id).listAll();
   }
 }

--- a/plentyofpets/lib/utils/firebase_auth_util.dart
+++ b/plentyofpets/lib/utils/firebase_auth_util.dart
@@ -76,7 +76,8 @@ class FirebaseAuthUtil {
   static Future<bool> createUserDocument(BuildContext context, NewUser newUser,
       UserCredential userCredential) async {
     bool result = true;
-    await usersCollection.add(newUser.toMap()).catchError((error) {
+    await usersCollection.doc(userCredential.user!.uid).set(
+      newUser.toMap()).catchError((error) {
       // Roll back user registration since document creation failed.
       userCredential.user!.delete();
       _showAuthErrorDialog(context, 'Error Registering',

--- a/plentyofpets/pubspec.lock
+++ b/plentyofpets/pubspec.lock
@@ -126,14 +126,35 @@ packages:
       name: firebase_core_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.3"
+    version: "4.2.4"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.3"
+    version: "1.5.4"
+  firebase_storage:
+    dependency: "direct main"
+    description:
+      name: firebase_storage
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "10.2.7"
+  firebase_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_storage_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.14"
+  firebase_storage_web:
+    dependency: transitive
+    description:
+      name: firebase_storage_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.2.8"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -204,12 +225,12 @@ packages:
     source: hosted
     version: "4.0.0"
   image_picker:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: image_picker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.4+6"
+    version: "0.8.4+8"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -252,6 +273,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -340,7 +368,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:
@@ -355,6 +383,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.1"
+  xfile:
+    dependency: "direct main"
+    description:
+      name: xfile
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
 sdks:
   dart: ">=2.15.1 <3.0.0"
   flutter: ">=2.5.0"

--- a/plentyofpets/pubspec.lock
+++ b/plentyofpets/pubspec.lock
@@ -126,14 +126,14 @@ packages:
       name: firebase_core_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.4"
+    version: "4.2.3"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.4"
+    version: "1.5.3"
   firebase_storage:
     dependency: "direct main"
     description:
@@ -368,7 +368,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:

--- a/plentyofpets/pubspec.yaml
+++ b/plentyofpets/pubspec.yaml
@@ -43,6 +43,9 @@ dependencies:
   form_builder_validators: ^7.4.0
   form_builder_image_picker: ^2.0.0
   provider: ^6.0.2
+  xfile: ^1.1.0
+  firebase_storage: ^10.2.7
+  image_picker: ^0.8.4+8
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
updated kotlin version due to error messages.  Added firebase storage.  Pictures on add pet form are now routed to firebase storage and url's are created for each pic and placed in firestore database.  Main pic field added to pets collection.  admin info captured and added to pets collection as well.  Modified registration slightly to match auth id to firebase document id to keep them in sync.